### PR TITLE
added additional missing parameter since the introduction of the docker_mode parameter

### DIFF
--- a/inception_ahd_recommender/ariadne/contrib/external_uima_classifier.py
+++ b/inception_ahd_recommender/ariadne/contrib/external_uima_classifier.py
@@ -88,6 +88,7 @@ def _as_named_tuple(dct: dict):
         },
         classifier=lower_dict.get("classifier"),
         processor=lower_dict.get("processor"),
+        docker_mode=lower_dict.get("docker_mode"),
     )
 
 
@@ -141,7 +142,7 @@ class ExternalClassifier(ABC):
         return (
             self._config
             if self._config is not None
-            else config_object(None, None, None, None, None, None, None)
+            else config_object(None, None, None, None, None, None, None, None)
         )
 
     @abstractmethod


### PR DESCRIPTION
Recommender Version 1.2.2 throws following exception:

```
Using the following address: https://averbis-dev.test.med.tu-dresden.de
with project: GeMTeX and
pipeline: deid and
with ResponseConsumer:
 'ariadne.contrib.external_server_consumer.MappingConsumer::/mapping_files/deid_mapping_singlelayer.json'
INFO:root:Authentication with Token: d1cd96...
[2024-12-12 12:03:27 +0000] [18] [ERROR] Exception in worker process
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/gunicorn/arbiter.py", line 608, in spawn_worker
    worker.init_process()
  File "/usr/local/lib/python3.7/site-packages/gunicorn/workers/base.py", line 135, in init_process
    self.load_wsgi()
  File "/usr/local/lib/python3.7/site-packages/gunicorn/workers/base.py", line 147, in load_wsgi
    self.wsgi = self.app.wsgi()
  File "/usr/local/lib/python3.7/site-packages/gunicorn/app/base.py", line 66, in wsgi
    self.callable = self.load()
  File "/usr/local/lib/python3.7/site-packages/gunicorn/app/wsgiapp.py", line 57, in load
    return self.load_wsgiapp()
  File "/usr/local/lib/python3.7/site-packages/gunicorn/app/wsgiapp.py", line 47, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/usr/local/lib/python3.7/site-packages/gunicorn/util.py", line 370, in import_app
    mod = importlib.import_module(module)
  File "/usr/local/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/inception_ahd_recommender/main.py", line 82, in <module>
    _server_handle, _classifier(config=_config, model_directory=_model_folder)
  File "/inception_ahd_recommender/ariadne/contrib/external_uima_classifier.py", line 273, in __init__
    super(AriadneClassifier, self).__init__(config, self.__class__.__name__)
  File "/inception_ahd_recommender/ariadne/contrib/external_uima_classifier.py", line 101, in __init__
    self._initialize_configuration(config)
  File "/inception_ahd_recommender/ariadne/contrib/external_uima_classifier.py", line 124, in _initialize_configuration
    self._config = _as_named_tuple(config)
  File "/inception_ahd_recommender/ariadne/contrib/external_uima_classifier.py", line 90, in _as_named_tuple
    processor=lower_dict.get("processor"),
TypeError: __new__() missing 1 required positional argument: 'docker_mode'
```

This is most probably because the construction of the named tuple object was still missing some parameters at some points.
This PR tries to resolve this bug.


Tested by building the container locally.